### PR TITLE
Resolve Rails 6.0 deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,8 @@ jobs:
         skip_cleanup: true
         github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
         keep_history: true
-
+    - name: Test Script
+      script: echo 'TESTING SECURITY';
 script: 'bundle exec rake'
 
 notifications:

--- a/lib/blocks/helpers/controller_extensions.rb
+++ b/lib/blocks/helpers/controller_extensions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'action_controller'
+require 'active_support/dependencies'
 
 module Blocks
   module ControllerExtensions
@@ -10,4 +10,6 @@ module Blocks
   end
 end
 
-ActionController::Base.send :include, Blocks::ControllerExtensions
+ActiveSupport.on_load(:action_controller) do
+  include Blocks::ControllerExtensions
+end

--- a/lib/blocks/version.rb
+++ b/lib/blocks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Blocks
-  VERSION = "4.0.0"
+  VERSION = "4.0.1"
 end


### PR DESCRIPTION
DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper.

Being able to do this is deprecated. Autoloading during initialization is going to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during initialization does not run again. So, if you reload ActionText::ContentHelper, for example, the expected changes won't be reflected in that stale Module object.

`config.autoloader` is set to `classic`. These autoloaded constants would have been unloaded if `config.autoloader` had been set to `:zeitwerk`.